### PR TITLE
Change zip name to exclude tag in release workflow

### DIFF
--- a/.github/workflows/manual_release_v2.yml
+++ b/.github/workflows/manual_release_v2.yml
@@ -153,7 +153,8 @@ jobs:
             --title "$(basename `git rev-parse --show-toplevel`) ${{ steps.get_tag.outputs.new_tag }}" \
             --notes "Automated release" \
             $release_flag \
-            "builds/$(basename `git rev-parse --show-toplevel`).zip"
+            "builds/$(basename `git rev-parse --show-toplevel`).zip" \
+            "builds/$(basename `git rev-parse --show-toplevel`)_${{ steps.get_tag.outputs.new_tag }}.zip"
 
 
 


### PR DESCRIPTION
Should allow for latest version download link: https://github.com/Squared-Media/squared-media-rig-ui/releases/latest/download/squared-media-rig-ui.zip